### PR TITLE
Add CFD fish detection pipeline v2

### DIFF
--- a/edge/cfd/Dockerfile.ultralytics-cfd-gpu
+++ b/edge/cfd/Dockerfile.ultralytics-cfd-gpu
@@ -1,0 +1,27 @@
+# CFD container rebuilt on the same base as da3-cuda-jetson
+# Fixes CUDA driver mismatch: uses PyTorch 2.2 + CUDA 12.2
+# (compatible with L4T r35.2.1 Jetson AGX Orin)
+FROM dustynv/l4t-pytorch:r36.2.0
+
+WORKDIR /app
+
+# Override pip index to use PyPI (base image's custom index is unreachable)
+ENV PIP_INDEX_URL=https://pypi.org/simple/
+ENV PIP_TRUSTED_HOST=pypi.org
+
+# Install ultralytics (YOLO framework) without replacing the working PyTorch
+RUN pip3 install --no-cache-dir ultralytics --no-deps && \
+    pip3 install --no-cache-dir \
+    py-cpuinfo psutil pyyaml tqdm requests pandas \
+    seaborn scipy thop ultralytics-thop
+
+# Install OpenCV without upgrading numpy (PyTorch 2.2 needs numpy<2)
+RUN pip3 install --no-cache-dir "opencv-python-headless<4.11" "numpy<2" 2>/dev/null || true
+
+# Download CFD model weights
+RUN wget -q https://github.com/WildHackers/community-fish-detector/releases/download/cfd-1.00-yolov12x/cfd-yolov12x-1.00.pt \
+    -O /app/cfd-yolov12x-1.00.pt
+
+COPY run_cfd.py /app/run_cfd.py
+
+ENTRYPOINT ["python3", "/app/run_cfd.py"]

--- a/edge/cfd/RUNBOOK.md
+++ b/edge/cfd/RUNBOOK.md
@@ -1,0 +1,136 @@
+# CFD Marine Pipeline v2 — Runbook
+
+## Overview
+
+Automated fish encounter counting on underwater transect video, calibrated
+against Benny's 27-year diver survey ground truth. Runs on Jetson AGX Orin
+64GB with GPU-accelerated inference.
+
+**Pipeline strategy** (per Octavio/head ecologist):
+1. Extract frames at 1/5s (not every frame)
+2. Run CFD fast pass to flag fish-present frames
+3. Apply skip window + ecological cap — deduplicate to unique encounters
+4. Run DA3 depth ONLY on encounter frames
+5. Output: encounter count comparable to diver survey methodology
+
+**Calibration result** (ESPERANZA T1 20m, Oct 2025):
+- Benny (diver): 17 species encounters
+- AI (pipeline): 23 detection events (+35%)
+- 6 extra events are likely re-sightings beyond the 10s skip window
+
+## Prerequisites
+
+- Jetson AGX Orin: `sshpass -p aburto ssh mza-bingi@10.1.102.97`
+- Docker images on Jetson:
+  - `ultralytics-cfd-gpu` — CFD fish detector (113ms/frame GPU)
+  - `da3-cuda-jetson` — Depth Anything 3 + ffmpeg
+- Video files on `/jetson-ssd/compute/edge/depth-anything-v3-marine/videos/`
+- Ground truth: `~/Desktop/peces_2023_2025.csv` (Benny's diver survey)
+
+## Quick Start
+
+```bash
+# SSH to Jetson
+sshpass -p aburto ssh mza-bingi@10.1.102.97
+
+# Run pipeline (default: cap=2)
+cd /jetson-ssd/compute/edge/cfd
+bash run_pipeline_v2.sh \
+  /jetson-ssd/compute/edge/depth-anything-v3-marine/videos/20251107_ESPERANZA_T1_20m_V1_AR.mp4 \
+  ESPERANZA T1 V1
+
+# Or override the ecological cap
+bash run_pipeline_v2.sh /path/to/video.mp4 ESPERANZA T1 V1 --max-per-event 3
+```
+
+## Compare Against Ground Truth
+
+```bash
+# On Mac (after scp'ing results)
+python3 compare_to_official.py \
+  --ai /jetson-ssd/pipeline/ESPERANZA/T1_V1/results/summary.csv \
+  --official ~/Desktop/peces_2023_2025.csv \
+  --reef ESPERANZA --depth 20 --transect 1 --year 2025
+```
+
+## Pipeline Stages & Timing (101 frames, 8K source)
+
+| Stage | What | Time |
+|-------|------|------|
+| 1. Frame extraction | ffmpeg 0.2fps from 8K video | ~41 min |
+| 2. CFD detection | YOLOv12x at imgsz=1024, GPU | ~12s (113ms/frame) |
+| 3. Deduplication | Skip window + ecological cap | instant |
+| 4. DA3 depth | Giant model on encounter frames only | ~8 min (23 frames) |
+| 5. Report | Summary CSV + JSON | instant |
+| **Total** | | **~50 min** |
+
+## Output Files
+
+```
+/jetson-ssd/pipeline/ESPERANZA/T1_V1/
+  frames/              101 extracted PNG frames
+  cfd/detections/      Per-frame detection JSON
+  depth/selected_frames/  Encounter frames (subset)
+  depth/output/        DA3 depth maps (mini_npz)
+  results/
+    summary.csv        One row per event: fish_count (capped), fish_count_raw, max_conf
+    detection_events.json   Full event data with bounding boxes
+```
+
+## Key Parameters
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `FPS` | 0.2 | 1 frame per 5 seconds |
+| `SKIP_WINDOW` | 1 | Skip N frames after detection (= 10s gap) |
+| `MAX_PER_EVENT` | 2 | Ecological cap per event (calibrated vs diver) |
+| `CONF` | 0.30 | YOLO confidence threshold |
+| `IMGSZ` | 1024 | Inference resolution (8K source letterboxed) |
+
+## Docker Images
+
+### ultralytics-cfd-gpu (current)
+
+Built on `dustynv/l4t-pytorch:r36.2.0`. PyTorch 2.2 + CUDA 12.2 compatible
+with L4T r35.2.1 driver on the Orin.
+
+```bash
+cd /jetson-ssd/compute/edge/cfd
+docker build -f Dockerfile.ultralytics-cfd-gpu -t ultralytics-cfd-gpu .
+```
+
+Critical build notes:
+- Must set `PIP_INDEX_URL=https://pypi.org/simple/` (base image's jetson index is offline)
+- Must pin `numpy<2` (PyTorch 2.2 incompatible with numpy 2.x)
+
+### da3-cuda-jetson
+
+Same base image. Contains DA3 model (`DA3NESTED-GIANT-LARGE-1.1`, 6.76GB)
+and ffmpeg. Used for both frame extraction (via `--entrypoint ffmpeg`) and
+depth inference.
+
+## Deploying Updates
+
+Source of truth is this repo (`mcam10/turing-pi-homelab`, `cfd/` directory).
+Deploy to Jetson with scp:
+
+```bash
+sshpass -p aburto scp cfd/*.py cfd/*.sh cfd/Dockerfile.* \
+  mza-bingi@10.1.102.97:/jetson-ssd/compute/edge/cfd/
+```
+
+## Known Issues
+
+- Frame extraction is slow (~41 min for 8K) — bottlenecked by ffmpeg decode, not GPU
+- Chromis at distance (<30px in 8K source, <4px at inference) are undetectable
+- Skip window doesn't catch fish that leave and re-enter frame after >10s
+- `BinGiTexh/compute.git` on the Jetson is a legacy repo; do not use it as source of truth
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 12s/frame inference | CPU fallback | Use `ultralytics-cfd-gpu`, not `ultralytics-cfd` |
+| `RuntimeError: Numpy is not available` | numpy 2.x installed | Rebuild with `numpy<2` pinned |
+| CUDA device not found | Wrong base image | Must use `dustynv/l4t-pytorch:r36.2.0` |
+| Stage 5 syntax error | Backslash in heredoc f-string | Fixed in current version |

--- a/edge/cfd/compare_to_official.py
+++ b/edge/cfd/compare_to_official.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Compare AI pipeline detection events against Benny's official diver survey.
+
+Usage:
+    python compare_to_official.py --ai summary.csv --official peces_2023_2025.csv \
+        --reef ESPERANZA --depth 20 --transect 1
+
+The official CSV has one row per species encounter on a transect:
+    Year, Month, Day, Region, Reef, Depth, Transect, Species
+
+The AI CSV (v2) has one row per detection event:
+    event_id, frame, fish_count, fish_count_raw, max_conf
+
+Primary comparison metric: number of detection events (AI) vs number of
+species encounters (Benny). Both represent "how many distinct fish were
+seen along the transect" — the AI just can't tell species apart.
+"""
+import argparse
+import csv
+import sys
+from collections import Counter
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+
+def load_official(path, reef, depth, transect, year=2025):
+    """Load Benny's CSV filtered to matching transect. Each row = 1 species encounter."""
+    species_counts = Counter()
+    total = 0
+    with open(path, newline='', encoding='utf-8-sig') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row['Reef'].strip().strip('"').upper() != reef.upper():
+                continue
+            if int(row['Depth']) != depth:
+                continue
+            if row['Transect'].strip().strip('"') != str(transect):
+                continue
+            if int(row['Year']) != year:
+                continue
+            species = row['Species'].strip().strip('"')
+            species_counts[species] += 1
+            total += 1
+    return species_counts, total
+
+
+def load_ai(path):
+    """Load AI pipeline summary CSV. Returns event count and per-event data."""
+    events = []
+    total_raw = 0
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames
+        # v2 format: event_id, frame, fish_count, [fish_count_raw], max_conf
+        if 'event_id' in fieldnames:
+            for row in reader:
+                raw = int(row.get('fish_count_raw', row['fish_count']))
+                total_raw += raw
+                events.append({
+                    'frame': row['frame'],
+                    'raw': raw,
+                    'max_conf': float(row['max_conf']),
+                })
+        # v1 format: frame, fish_count_raw, fish_count_filtered, ...
+        else:
+            for row in reader:
+                raw = int(row['fish_count_raw'])
+                filtered = int(row['fish_count_filtered'])
+                if filtered > 0:
+                    total_raw += raw
+                    events.append({
+                        'frame': row['frame'],
+                        'raw': raw,
+                        'max_conf': float(row['max_conf']),
+                    })
+    n_events = len(events)
+    return events, n_events, total_raw
+
+
+def classify_by_size(species_counts):
+    """Rough size classification of species for analysis."""
+    small_species = {
+        'Chromis limbaughi', 'Chromis atrilobata', 'Azurina atrilobata',
+        'Stegastes rectifraenum', 'Stegastes flavilatus', 'Stegastes acapulcoensis',
+        'Thalassoma lucasanum', 'Halichoeres dispilus', 'Halichoeres nicholsi',
+        'Cirrhitichthys oxycephalus', 'Ophioblennius steindachneri',
+        'Plagiotremus azaleus', 'Canthigaster punctatissima',
+        'Serranus psittacinus', 'Johnrandallia nigrirostris',
+        'Abudefduf troschelii',
+    }
+    medium_species = {
+        'Prionurus punctatus', 'Prionurus laticlavius', 'Sufflamen verres',
+        'Holacanthus passer', 'Bodianus diplotaenia', 'Mulloidichthys dentatus',
+        'Scarus ghobban', 'Scarus compressus', 'Scarus rubroviolaceus',
+        'Haemulon sexfasciatum', 'Haemulon maculicauda',
+        'Arothron meleagris', 'Ostracion meleagris', 'Diodon holocanthus',
+        'Myripristis leiognathus',
+    }
+    large_species = {
+        'Lutjanus argentiventris', 'Lutjanus novemfasciatus', 'Lutjanus viridis',
+        'Mycteroperca rosacea', 'Epinephelus labriformis',
+        'Cephalopholis panamensis', 'Cephalopholis colonus',
+        'Fistularia commersonii', 'Gymnothorax castaneus',
+        'Seriola lalandi', 'Caranx caninus',
+    }
+
+    buckets = {'small (<15cm)': 0, 'medium (15-40cm)': 0, 'large (>40cm)': 0, 'unclassified': 0}
+    for sp, count in species_counts.items():
+        if sp in small_species:
+            buckets['small (<15cm)'] += count
+        elif sp in medium_species:
+            buckets['medium (15-40cm)'] += count
+        elif sp in large_species:
+            buckets['large (>40cm)'] += count
+        else:
+            buckets['unclassified'] += count
+    return buckets
+
+
+def write_report(species_counts, ai_events, output_dir):
+    """Write comparison_report.csv."""
+    rows = []
+    benny_total = sum(species_counts.values())
+
+    for species, count in sorted(species_counts.items(), key=lambda x: -x[1]):
+        rows.append({
+            'category': species,
+            'benny_encounters': count,
+            'ai_events': '-',
+            'difference': '-',
+            'pct_difference': '-',
+        })
+
+    rows.append({
+        'category': '--- TOTALS ---',
+        'benny_encounters': benny_total,
+        'ai_events': ai_events,
+        'difference': ai_events - benny_total,
+        'pct_difference': f"{((ai_events - benny_total) / benny_total * 100):.1f}%" if benny_total else 'N/A',
+    })
+
+    out_path = output_dir / 'comparison_report.csv'
+    with open(out_path, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=[
+            'category', 'benny_encounters', 'ai_events', 'difference', 'pct_difference'])
+        writer.writeheader()
+        writer.writerows(rows)
+    return out_path
+
+
+def make_chart(species_counts, ai_events, size_buckets, output_dir):
+    """Bar chart: Benny species encounters vs AI detection events."""
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+
+    # Left panel: encounter comparison
+    ax = axes[0]
+    benny_total = sum(species_counts.values())
+    bars = ax.bar(
+        ['Diver\n(species encounters)', 'AI\n(detection events)'],
+        [benny_total, ai_events],
+        color=['#2196F3', '#4CAF50'], edgecolor='black', linewidth=0.5)
+    ax.set_ylabel('Number of encounters / events')
+    ax.set_title('Fish Encounters: Diver Survey vs AI Pipeline')
+    for bar, val in zip(bars, [benny_total, ai_events]):
+        ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.5,
+                str(val), ha='center', va='bottom', fontweight='bold')
+    diff_pct = ((ai_events - benny_total) / benny_total * 100) if benny_total else 0
+    ax.text(0.5, 0.92, f"AI is {diff_pct:+.1f}% vs diver",
+            transform=ax.transAxes, ha='center', fontsize=10, style='italic')
+
+    # Right panel: size bucket breakdown
+    ax = axes[1]
+    bucket_names = [k for k in size_buckets.keys() if size_buckets[k] > 0]
+    bucket_vals = [size_buckets[k] for k in bucket_names]
+    colors = {'small (<15cm)': '#FF9800', 'medium (15-40cm)': '#2196F3',
+              'large (>40cm)': '#9C27B0', 'unclassified': '#9E9E9E'}
+    bar_colors = [colors.get(k, '#9E9E9E') for k in bucket_names]
+    bars = ax.bar(bucket_names, bucket_vals, color=bar_colors, edgecolor='black', linewidth=0.5)
+    ax.set_ylabel('Count (diver)')
+    ax.set_title("Diver Species by Size Class\n(AI detects all as generic 'fish')")
+    for bar, val in zip(bars, bucket_vals):
+        ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.3,
+                str(val), ha='center', va='bottom', fontsize=9)
+    ax.tick_params(axis='x', rotation=15)
+
+    plt.tight_layout()
+    chart_path = output_dir / 'comparison_chart.png'
+    plt.savefig(chart_path, dpi=150)
+    plt.close()
+    return chart_path
+
+
+def print_summary(species_counts, ai_events, ai_raw, size_buckets, events, year):
+    """Print readable terminal summary."""
+    benny_total = sum(species_counts.values())
+    diff = ai_events - benny_total
+    pct = (diff / benny_total * 100) if benny_total else 0
+
+    print("\n" + "=" * 70)
+    print("  ESPERANZA TRANSECT — AI vs DIVER COMPARISON")
+    print("=" * 70)
+
+    print(f"\n  WHAT EACH NUMBER MEANS")
+    print(f"  " + "-" * 66)
+    print(f"  Benny (diver):  Each row in his CSV is one species encounter — a fish")
+    print(f"                  he identified and recorded while swimming the transect.")
+    print(f"                  His {year} survey logged {benny_total} encounters ({len(species_counts)} species).")
+    print(f"  AI (pipeline):  Each detection event is a moment in the video where")
+    print(f"                  the model saw fish that weren't in the previous frame.")
+    print(f"                  The AI cannot identify species — it only knows 'fish'.")
+    print(f"  " + "-" * 66)
+
+    print(f"\n  {'METRIC':<40} {'DIVER':>10} {'AI':>10}")
+    print(f"  " + "-" * 62)
+    print(f"  {'Species encounters (diver) / events (AI)':<40} {benny_total:>10} {ai_events:>10}")
+    print(f"  {'Raw fish detections (before dedup)':<40} {'—':>10} {ai_raw:>10}")
+    print(f"  {'Difference':<40} {'':>10} {diff:>+10}")
+    print(f"  {'Percent difference':<40} {'':>10} {pct:>+9.1f}%")
+
+    print(f"\n  {'SIZE CLASS (diver breakdown)':<35} {'Count':>8} {'% of total':>12}")
+    print(f"  " + "-" * 55)
+    for bucket, count in sorted(size_buckets.items(), key=lambda x: -x[1]):
+        if count > 0:
+            pct_b = count / benny_total * 100 if benny_total else 0
+            print(f"    {bucket:<33} {count:>8} {pct_b:>10.1f}%")
+
+    print(f"\n  {'SPECIES LIST (diver, {})'.format(year):<35} {'Count':>8}")
+    print(f"  " + "-" * 45)
+    for species, count in sorted(species_counts.items(), key=lambda x: -x[1]):
+        print(f"    {species:<33} {count:>8}")
+
+    # Event-level stats
+    if events:
+        confs = [e['max_conf'] for e in events]
+        print(f"\n  {'AI EVENT STATISTICS':<35}")
+        print(f"  " + "-" * 45)
+        print(f"    {'Total detection events':<33} {len(events):>8}")
+        print(f"    {'Mean confidence':<33} {sum(confs)/len(confs):>8.3f}")
+        print(f"    {'Min confidence':<33} {min(confs):>8.3f}")
+        print(f"    {'Max confidence':<33} {max(confs):>8.3f}")
+        high_conf = sum(1 for c in confs if c >= 0.50)
+        print(f"    {'Events with conf >= 0.50':<33} {high_conf:>8}")
+
+    print("\n" + "=" * 70)
+    print("  INTERPRETATION")
+    print("=" * 70)
+    if diff > 0:
+        print(f"\n  AI detects {diff} MORE events than the diver logged ({pct:+.1f}%)")
+        print(f"  Likely causes:")
+        print(f"    - Re-sighting: same fish appears in multiple non-consecutive frames")
+        print(f"    - The diver swims a 25m line; the camera's field of view may")
+        print(f"      capture fish off-transect that the diver would not count")
+        print(f"    - Skip window (10s) may be too short for slow-moving fish")
+    else:
+        print(f"\n  AI detects {abs(diff)} FEWER events than the diver logged ({pct:+.1f}%)")
+        print(f"  Likely causes:")
+        print(f"    - Small/camouflaged fish below detection threshold")
+        print(f"    - Fish in background missed at inference resolution")
+        print(f"    - Brief appearances between sampled frames (1 per 5s)")
+
+    print(f"\n  NOTE: The diver identifies species; the AI only detects presence.")
+    print(f"  A perfect AI would match the diver's encounter count even without")
+    print(f"  species ID — both are answering 'how many distinct fish did I see?'")
+
+    print("\n" + "=" * 70 + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare AI detection events vs diver species encounters")
+    parser.add_argument('--ai', required=True, help='AI pipeline summary.csv')
+    parser.add_argument('--official', required=True, help="Benny's peces CSV")
+    parser.add_argument('--reef', default='ESPERANZA', help='Reef name to filter')
+    parser.add_argument('--depth', type=int, default=20, help='Depth in meters')
+    parser.add_argument('--transect', default='1', help='Transect number')
+    parser.add_argument('--year', type=int, default=2025, help='Survey year (default: 2025)')
+    parser.add_argument('--output', default='.', help='Output directory')
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    species_counts, benny_total = load_official(
+        args.official, args.reef, args.depth, args.transect, args.year)
+
+    if benny_total == 0:
+        print(f"ERROR: No records found for Reef={args.reef}, Depth={args.depth}, "
+              f"Transect={args.transect}, Year={args.year}")
+        print("Available combinations in file:")
+        with open(args.official, newline='', encoding='utf-8-sig') as f:
+            combos = set()
+            for row in csv.DictReader(f):
+                combos.add((row['Reef'].strip().strip('"'),
+                            row['Depth'].strip(), row['Year'].strip()))
+        for reef, depth, year in sorted(combos):
+            print(f"  {reef} / {depth}m / {year}")
+        sys.exit(1)
+
+    events, ai_events, ai_raw = load_ai(args.ai)
+    size_buckets = classify_by_size(species_counts)
+
+    print_summary(species_counts, ai_events, ai_raw, size_buckets, events, args.year)
+
+    report_path = write_report(species_counts, ai_events, output_dir)
+    print(f"  Report saved: {report_path}")
+
+    chart_path = make_chart(species_counts, ai_events, size_buckets, output_dir)
+    print(f"  Chart saved:  {chart_path}\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/edge/cfd/fuse_depth_cfd.py
+++ b/edge/cfd/fuse_depth_cfd.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fuse CFD fish detections with DA3 depth maps."""
+import argparse, json, csv, os
+from pathlib import Path
+import numpy as np
+import cv2
+
+
+def depth_to_color(depth_m, d_min=0.5, d_max=10.0):
+    """Map depth to BGR color: green(shallow) -> yellow(mid) -> red(deep)."""
+    t = np.clip((depth_m - d_min) / (d_max - d_min), 0, 1)
+    if t < 0.5:
+        # green -> yellow
+        r, g, b = int(255 * t * 2), 255, 0
+    else:
+        # yellow -> red
+        r, g, b = 255, int(255 * (1 - (t - 0.5) * 2)), 0
+    return (b, g, r)  # BGR
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--frames", required=True)
+    p.add_argument("--depth", required=True)
+    p.add_argument("--cfd", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--site", default="SITE")
+    p.add_argument("--transect", default="T1")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    frames_dir = Path(args.frames)
+    depth_dir = Path(args.depth)
+    cfd_dir = Path(args.cfd)
+    out_dir = Path(args.output)
+    fused_dir = out_dir / "fused_annotated"
+    fused_dir.mkdir(parents=True, exist_ok=True)
+
+    det_files = sorted((cfd_dir / "detections").glob("*.json"))
+    if not det_files:
+        print("No detection JSONs found"); return
+
+    rows = []
+    all_depths = []
+    best_frame, best_count = None, 0
+
+    for det_path in det_files:
+        stem = det_path.stem
+        with open(det_path) as f:
+            det = json.load(f)
+
+        depth_path = depth_dir / f"{stem}.npy"
+        if not depth_path.exists():
+            continue
+
+        depth = np.load(str(depth_path))
+        dh, dw = depth.shape
+        frame_path = frames_dir / det["frame"]
+        img = cv2.imread(str(frame_path))
+        if img is None:
+            continue
+        fh, fw = img.shape[:2]
+        sy, sx = dh / fh, dw / fw
+
+        fish_dets = [d for d in det["detections"] if not d["likely_diver"]]
+        for d in fish_dets:
+            cx, cy = d["center"]
+            dx, dy = int(cx * sx), int(cy * sy)
+            dx, dy = min(dx, dw-1), min(dy, dh-1)
+            z = float(depth[dy, dx])
+            d["depth_m"] = round(z, 3)
+            all_depths.append(z)
+
+            color = depth_to_color(z)
+            x1, y1, x2, y2 = [int(v) for v in d["bbox"]]
+            cv2.rectangle(img, (x1,y1), (x2,y2), color, 2)
+            lbl = f"{d['confidence']:.2f} {z:.1f}m"
+            cv2.putText(img, lbl, (x1, y1-5),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1)
+
+        # diver boxes in orange
+        for d in det["detections"]:
+            if d["likely_diver"]:
+                x1,y1,x2,y2 = [int(v) for v in d["bbox"]]
+                cv2.rectangle(img, (x1,y1),(x2,y2), (0,165,255), 2)
+
+        n_fish = len(fish_dets)
+        txt = f"{stem} | Fish:{n_fish}"
+        cv2.putText(img, txt, (10,30),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0,255,0), 2)
+
+        scale = 1920/fw if fw > 1920 else 1.0
+        if scale < 1.0:
+            img = cv2.resize(img, (1920, int(fh*scale)))
+        cv2.imwrite(str(fused_dir/f"{stem}.jpg"), img,
+                    [cv2.IMWRITE_JPEG_QUALITY, 85])
+
+        fish_depths = [d["depth_m"] for d in fish_dets if "depth_m" in d]
+        mean_d = np.mean(fish_depths) if fish_depths else 0
+        rows.append({
+            "frame": det["frame"], "fish_count": n_fish,
+            "mean_depth_m": round(mean_d, 3),
+            "min_depth_m": round(min(fish_depths), 3) if fish_depths else 0,
+            "max_depth_m": round(max(fish_depths), 3) if fish_depths else 0,
+        })
+        if n_fish > best_count:
+            best_count = n_fish
+            best_frame = stem
+
+    # CSV
+    with open(out_dir/"fused_summary.csv", "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=[
+            "frame","fish_count","mean_depth_m","min_depth_m","max_depth_m"])
+        w.writeheader(); w.writerows(rows)
+
+    # Best frame highlight
+    if best_frame:
+        src = fused_dir / f"{best_frame}.jpg"
+        if src.exists():
+            import shutil
+            shutil.copy(str(src), str(out_dir/"best_frame_highlight.jpg"))
+
+    # Filmstrip: top 5 frames by fish count
+    top5 = sorted(rows, key=lambda r: r["fish_count"], reverse=True)[:5]
+    strips = []
+    for r in top5:
+        stem = Path(r["frame"]).stem
+        p = fused_dir / f"{stem}.jpg"
+        if p.exists():
+            im = cv2.imread(str(p))
+            im = cv2.resize(im, (384, 216))
+            strips.append(im)
+    if strips:
+        filmstrip = np.hstack(strips)
+        cv2.imwrite(str(out_dir/"filmstrip.jpg"), filmstrip,
+                    [cv2.IMWRITE_JPEG_QUALITY, 90])
+
+    # Console report
+    ad = np.array(all_depths) if all_depths else np.array([0])
+    print(f"\n=== FUSION RESULTS: {args.site} {args.transect} ===")
+    print(f"Frames processed: {len(rows)}")
+    print(f"Total fish (filtered): {sum(r['fish_count'] for r in rows)}")
+    print(f"Depth range: {ad.min():.2f}m - {ad.max():.2f}m")
+    print(f"Depth range (5th-95th pct): {np.percentile(ad,5):.2f}m - {np.percentile(ad,95):.2f}m")
+    print(f"Mean fish depth: {ad.mean():.2f}m")
+    print(f"Median fish depth: {np.median(ad):.2f}m")
+    print(f"Best frame: {best_frame} ({best_count} fish)")
+    print(f"Top 5: {[(r['frame'], r['fish_count']) for r in top5]}")
+    print(f"Output: {out_dir}")
+    print("=" * 40)
+
+
+if __name__ == "__main__":
+    main()

--- a/edge/cfd/fused_overlay.py
+++ b/edge/cfd/fused_overlay.py
@@ -1,0 +1,115 @@
+import numpy as np
+import cv2, json, glob, os
+
+BASE       = "/jetson-ssd/compute/edge/depth-anything-v3-marine/ESPERANZA/T1_20m/V1/"
+FRAMES_DIR = BASE + "frames/"
+DEPTH_DIR  = BASE + "depth/"
+CFD_DIR    = BASE + "cfd/detections/"
+OUT_DIR    = BASE + "fused_overlay/"
+os.makedirs(OUT_DIR, exist_ok=True)
+FPB = 8
+
+def get_dvis(fn):
+    return os.path.join(DEPTH_DIR, f"batch_{fn//FPB:04d}", "depth_vis", f"{fn%FPB:04d}.jpg")
+
+def depth_color_at(dvis, cx, cy):
+    h,w = dvis.shape[:2]
+    cx,cy = min(max(cx,0),w-1), min(max(cy,0),h-1)
+    b,g,r = [int(v) for v in dvis[cy,cx]]
+    return (b,g,r)
+
+def draw_boxes(img, dets, dvis=None):
+    for d in dets:
+        x1,y1,x2,y2 = [int(v) for v in d["bbox"]]
+        dv = d.get("likely_diver", False)
+        if dvis is not None:
+            cx,cy = (x1+x2)//2, (y1+y2)//2
+            c = depth_color_at(dvis, cx, cy)
+        else:
+            c = (0,100,255) if dv else (0,220,80)
+        cv2.rectangle(img,(x1,y1),(x2,y2),c,3)
+        label = f"{'D' if dv else 'F'} {d['confidence']:.2f}"
+        cv2.putText(img,label,(x1+2,max(y1-6,18)),
+                    cv2.FONT_HERSHEY_SIMPLEX,0.55,c,2,cv2.LINE_AA)
+    return img
+
+def add_minimap(img, dvis, scale=0.25):
+    h,w = img.shape[:2]
+    mw,mh = int(w*scale), int(h*scale)
+    mini = cv2.resize(dvis,(mw,mh),interpolation=cv2.INTER_LANCZOS4)
+    cv2.rectangle(mini,(0,0),(mw-1,mh-1),(255,255,255),3)
+    margin = 10
+    y1,y2 = h-mh-margin, h-margin
+    x1,x2 = w-mw-margin, w-margin
+    roi = img[y1:y2, x1:x2]
+    cv2.addWeighted(mini, 0.85, roi, 0.15, 0, roi)
+    img[y1:y2, x1:x2] = roi
+    cv2.putText(img,"DEPTH",(x1+6,y1+20),
+                cv2.FONT_HERSHEY_SIMPLEX,0.5,(255,255,255),1,cv2.LINE_AA)
+    return img
+
+def banner(img, text):
+    h,w = img.shape[:2]
+    ov = img.copy(); cv2.rectangle(ov,(0,0),(w,52),(0,0,0),-1)
+    cv2.addWeighted(ov,0.6,img,0.4,0,img)
+    cv2.putText(img,text,(12,36),cv2.FONT_HERSHEY_SIMPLEX,0.8,(80,255,160),2,cv2.LINE_AA)
+    return img
+
+for fn in [117,118,119,120,121]:
+    stem = f"{fn:06d}"
+    fp = os.path.join(FRAMES_DIR, stem+".png")
+    jp = os.path.join(CFD_DIR, stem+".json")
+    dp = get_dvis(fn)
+    if not os.path.exists(fp) or not os.path.exists(jp): continue
+    with open(jp) as f: det = json.load(f)
+    fish_n = det.get("fish_count_filtered",0)
+    divers = det.get("diver_detections",0)
+    img = cv2.imread(fp); h,w = img.shape[:2]
+    dvis = cv2.resize(cv2.imread(dp),(w,h)) if os.path.exists(dp) else None
+    draw_boxes(img, det.get("detections",[]), dvis)
+    if dvis is not None:
+        add_minimap(img, dvis)
+    banner(img, f"CFD+Depth | {stem} | {fish_n} fish | {divers} divers")
+    out = cv2.resize(img,(3840,int(h*3840/w)),interpolation=cv2.INTER_LANCZOS4)
+    cv2.imwrite(os.path.join(OUT_DIR,f"{stem}_fused.jpg"),out,[cv2.IMWRITE_JPEG_QUALITY,97])
+    print(f"  Saved {stem}_fused.jpg  ({out.shape[1]}x{out.shape[0]})")
+
+print("Building filmstrip...")
+all_j = sorted(glob.glob(os.path.join(CFD_DIR,"*.json")))
+spaced = [int(os.path.splitext(os.path.basename(all_j[i]))[0]) for i in np.linspace(0,len(all_j)-1,5,dtype=int)]
+all_strip = sorted(set(spaced+[119,120,121]))[:8]
+SW,SH = 640,360
+panels = []
+for fn in all_strip:
+    stem=f"{fn:06d}"; jp=os.path.join(CFD_DIR,stem+".json")
+    fp=os.path.join(FRAMES_DIR,stem+".png"); dp=get_dvis(fn)
+    fish_n=0; dets=[]
+    if os.path.exists(jp):
+        with open(jp) as f: d=json.load(f)
+        fish_n=d.get("fish_count_filtered",0); dets=d.get("detections",[])
+    if not os.path.exists(fp): continue
+    img = cv2.imread(fp); h,w = img.shape[:2]
+    dvis = cv2.resize(cv2.imread(dp),(w,h)) if os.path.exists(dp) else None
+    draw_boxes(img, dets, dvis)
+    if dvis is not None:
+        add_minimap(img, dvis, scale=0.3)
+    panel = cv2.resize(img,(SW,SH),interpolation=cv2.INTER_LANCZOS4)
+    hot = fn in [119,120,121]
+    if hot:
+        cv2.rectangle(panel,(0,0),(SW-1,SH-1),(0,180,255),3)
+    lb = np.full((40,SW,3),15,dtype=np.uint8)
+    tag = "* " if hot else ""
+    cv2.putText(lb,f"{tag}{stem} | {fish_n} fish",(6,28),
+                cv2.FONT_HERSHEY_SIMPLEX,0.6,(0,200,255) if hot else (80,255,160),1,cv2.LINE_AA)
+    panels.append(np.vstack([panel,lb]))
+
+gap = np.full((panels[0].shape[0],8,3),25,dtype=np.uint8)
+strip = panels[0]
+for p in panels[1:]: strip = np.hstack([strip,gap,p])
+hdr = np.full((70,strip.shape[1],3),15,dtype=np.uint8)
+cv2.putText(hdr,"ESPERANZA T1 | CFD + Depth-Colored Boxes + Minimap | * = hotspot",(16,48),
+            cv2.FONT_HERSHEY_SIMPLEX,0.85,(80,255,160),2,cv2.LINE_AA)
+filmstrip = np.vstack([hdr,strip])
+cv2.imwrite(os.path.join(OUT_DIR,"filmstrip_fused.jpg"),filmstrip,[cv2.IMWRITE_JPEG_QUALITY,97])
+print("Filmstrip saved.")
+print("Files:",os.listdir(OUT_DIR))

--- a/edge/cfd/run_cfd.py
+++ b/edge/cfd/run_cfd.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Community Fish Detector (CFD) pipeline - Stage 2."""
+import argparse
+import json
+import csv
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+from ultralytics import YOLO
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="CFD fish detection")
+    p.add_argument("--frames", default="/outputs/frames")
+    p.add_argument("--output", default="/outputs/cfd")
+    p.add_argument("--model", default="/app/cfd-yolov12x-1.00.pt")
+    p.add_argument("--conf", type=float, default=0.3)
+    p.add_argument("--imgsz", type=int, default=1024)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    frames_dir = Path(args.frames)
+    output_dir = Path(args.output)
+    det_dir = output_dir / "detections"
+    ann_dir = output_dir / "annotated"
+    det_dir.mkdir(parents=True, exist_ok=True)
+    ann_dir.mkdir(parents=True, exist_ok=True)
+
+    pngs = sorted(frames_dir.glob("*.png"))
+    if not pngs:
+        print(f"No PNG files found in {frames_dir}")
+        return
+
+    print(f"Found {len(pngs)} frames in {frames_dir}")
+    model = YOLO(args.model)
+
+    results = model.predict(
+        source=str(frames_dir),
+        imgsz=args.imgsz,
+        conf=args.conf,
+        stream=True,
+    )
+
+    csv_rows = []
+    total_raw = 0
+    total_filtered = 0
+    total_diver = 0
+    zero_fish = 0
+    frame_counts = []
+
+    for result in results:
+        src = Path(result.path)
+        stem = src.stem
+        img = cv2.imread(str(src))
+        h, w = img.shape[:2]
+        frame_area = h * w
+
+        detections = []
+        for box in result.boxes:
+            x1, y1, x2, y2 = box.xyxy[0].cpu().numpy().tolist()
+            conf = float(box.conf[0].cpu())
+            cx = (x1 + x2) / 2
+            cy = (y1 + y2) / 2
+            bw = x2 - x1
+            bh = y2 - y1
+            area_pct = (bw * bh) / frame_area
+            likely_diver = area_pct > 0.10 or y2 < h * 0.20
+            detections.append({
+                "bbox": [round(x1, 1), round(y1, 1), round(x2, 1), round(y2, 1)],
+                "confidence": round(conf, 4),
+                "center": [round(cx, 1), round(cy, 1)],
+                "area_pct": round(area_pct, 5),
+                "likely_diver": likely_diver,
+            })
+
+        fish = [d for d in detections if not d["likely_diver"]]
+        divers = [d for d in detections if d["likely_diver"]]
+
+        frame_json = {
+            "frame": src.name,
+            "fish_count": len(detections),
+            "detections": detections,
+            "fish_count_filtered": len(fish),
+            "diver_detections": len(divers),
+        }
+        with open(det_dir / f"{stem}.json", "w") as f:
+            json.dump(frame_json, f, indent=2)
+
+        # Annotated image
+        for d in detections:
+            x1, y1, x2, y2 = [int(v) for v in d["bbox"]]
+            if d["likely_diver"]:
+                color = (0, 165, 255)  # orange BGR
+            else:
+                color = (0, 255, 0)  # green BGR
+            cv2.rectangle(img, (x1, y1), (x2, y2), color, 2)
+            label = f"{d['confidence']:.2f}"
+            cv2.putText(img, label, (x1, y1 - 5),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1)
+
+        txt = f"Frame: {stem}  Fish: {len(fish)}"
+        cv2.putText(img, txt, (10, 30),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 255, 0), 2)
+
+        scale = 1920 / w if w > 1920 else 1.0
+        if scale < 1.0:
+            img = cv2.resize(img, (1920, int(h * scale)))
+        cv2.imwrite(str(ann_dir / f"{stem}.jpg"), img,
+                    [cv2.IMWRITE_JPEG_QUALITY, 85])
+
+        confs = [d["confidence"] for d in fish] if fish else [0]
+        csv_rows.append({
+            "frame": src.name,
+            "fish_count_raw": len(detections),
+            "fish_count_filtered": len(fish),
+            "diver_detections": len(divers),
+            "max_conf": round(max(confs), 4),
+            "mean_conf": round(sum(confs) / len(confs), 4),
+        })
+
+        total_raw += len(detections)
+        total_filtered += len(fish)
+        total_diver += len(divers)
+        if len(fish) == 0:
+            zero_fish += 1
+        frame_counts.append((src.name, len(fish)))
+
+        print(f"  {src.name}: {len(fish)} fish, {len(divers)} diver")
+
+    # Write CSV
+    with open(output_dir / "summary.csv", "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=[
+            "frame", "fish_count_raw", "fish_count_filtered",
+            "diver_detections", "max_conf", "mean_conf"])
+        writer.writeheader()
+        writer.writerows(csv_rows)
+
+    # Console report
+    n = len(pngs)
+    mean_fish = total_filtered / n if n else 0
+    top5 = sorted(frame_counts, key=lambda x: x[1], reverse=True)[:5]
+    print("\n=== CFD RESULTS ===")
+    print(f"Total frames processed: {n}")
+    print(f"Total fish detections (raw): {total_raw}")
+    print(f"Total fish detections (filtered): {total_filtered}")
+    print(f"Likely diver detections removed: {total_diver}")
+    print(f"Mean fish per frame: {mean_fish:.2f}")
+    print(f"Frames with 0 fish: {zero_fish}")
+    print(f"Top 5 frames by fish count: {top5}")
+    print("==================")
+
+
+if __name__ == "__main__":
+    main()

--- a/edge/cfd/run_pipeline_v2.sh
+++ b/edge/cfd/run_pipeline_v2.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# Optimized Marine Video Pipeline v2
+# CFD-first filtering with skip-window deduplication
+#
+# Strategy (per Octavio/head ecologist):
+#   1. Extract frames at 1/5s (not every frame)
+#   2. Run CFD fast pass to flag fish-present frames
+#   3. Apply skip window — same school = one detection event
+#   4. Run DA3 depth ONLY on unique detection events
+#   5. Output: deduplicated fish count comparable to diver survey
+#
+# Usage: ./run_pipeline_v2.sh <video_path> <site> <transect> <version> [--max-per-event N]
+# Example: ./run_pipeline_v2.sh /jetson-ssd/videos/T1.mp4 ESPERANZA T1 V1 --max-per-event 2
+
+set -e
+
+VIDEO=$1
+SITE=${2:-ESPERANZA}
+TRANSECT=${3:-T1}
+VERSION=${4:-V1}
+
+# Ecological cap: max fish counted per unique detection event.
+# Calibrated to match diver survey methodology (cap=2 → -6% vs manual
+# count on ESPERANZA T1).
+MAX_PER_EVENT=2
+
+# Parse optional flags
+shift 4 2>/dev/null || true
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --max-per-event) MAX_PER_EVENT="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+PIPELINE_ROOT=/jetson-ssd/pipeline/$SITE/${TRANSECT}_${VERSION}
+FRAMES_DIR=$PIPELINE_ROOT/frames
+CFD_DIR=$PIPELINE_ROOT/cfd
+DEPTH_DIR=$PIPELINE_ROOT/depth
+RESULTS_DIR=$PIPELINE_ROOT/results
+
+FPS=0.2  # 1 frame per 5 seconds
+SKIP_WINDOW=1  # skip N frames after detection (= 5s at 0.2fps)
+CONF=0.30
+IMGSZ=1024
+
+echo "=============================================="
+echo "  Marine Pipeline v2 — CFD-First Filtering"
+echo "=============================================="
+echo "Video:       $VIDEO"
+echo "Site:        $SITE / $TRANSECT / $VERSION"
+echo "Output:      $PIPELINE_ROOT"
+echo "Sampling:    ${FPS} fps (1 frame per 5 seconds)"
+echo "Skip window: ${SKIP_WINDOW} frames (5s after detection)"
+echo "Max/event:   ${MAX_PER_EVENT} fish (ecological cap)"
+echo "=============================================="
+echo ""
+
+mkdir -p $FRAMES_DIR $CFD_DIR $DEPTH_DIR $RESULTS_DIR
+
+# ─── STAGE 1: Extract frames at 1/5s ───────────────────────────────────
+echo "=== STAGE 1: Frame Extraction (${FPS} fps) ==="
+START=$(date +%s)
+
+docker run --rm --runtime nvidia \
+  -v /jetson-ssd:/jetson-ssd \
+  --entrypoint ffmpeg \
+  da3-cuda-jetson \
+  -i "$VIDEO" \
+  -vf "fps=$FPS" \
+  -q:v 2 \
+  "$FRAMES_DIR/%06d.png" \
+  -y 2>/dev/null
+
+FRAME_COUNT=$(ls $FRAMES_DIR/*.png 2>/dev/null | wc -l)
+ELAPSED=$(($(date +%s) - START))
+echo "  Extracted $FRAME_COUNT frames in ${ELAPSED}s"
+echo ""
+
+# ─── STAGE 2: CFD fast pass ─────────────────────────────────────────────
+echo "=== STAGE 2: CFD Fish Detection (fast pass) ==="
+START=$(date +%s)
+
+docker run --rm --runtime nvidia \
+  -v $PIPELINE_ROOT:/outputs \
+  ultralytics-cfd-gpu \
+  --frames /outputs/frames \
+  --output /outputs/cfd \
+  --conf $CONF \
+  --imgsz $IMGSZ
+
+ELAPSED=$(($(date +%s) - START))
+echo "  CFD complete in ${ELAPSED}s"
+echo ""
+
+# ─── STAGE 3: Skip-window deduplication ─────────────────────────────────
+echo "=== STAGE 3: Deduplication (skip window = ${SKIP_WINDOW} frames) ==="
+
+python3 << PYEOF
+import csv, json, shutil, os
+from pathlib import Path
+
+cfd_dir = Path("$CFD_DIR")
+results_dir = Path("$RESULTS_DIR")
+frames_dir = Path("$FRAMES_DIR")
+depth_dir = Path("$DEPTH_DIR")
+skip_window = $SKIP_WINDOW
+max_per_event = $MAX_PER_EVENT
+
+det_dir = cfd_dir / "detections"
+depth_frames_dir = depth_dir / "selected_frames"
+depth_frames_dir.mkdir(parents=True, exist_ok=True)
+
+# Read per-frame fish counts
+frame_files = sorted(det_dir.glob("*.json"))
+events = []
+last_event_idx = -999
+
+for i, jf in enumerate(frame_files):
+    with open(jf) as f:
+        data = json.load(f)
+
+    fish_count = data.get("fish_count_filtered", 0)
+    if fish_count == 0:
+        continue
+
+    # Skip window: if this frame is within skip_window of last event, skip it
+    if i - last_event_idx <= skip_window:
+        continue
+
+    # This is a new detection event
+    last_event_idx = i
+    frame_name = data["frame"]
+    fish = [d for d in data["detections"] if not d["likely_diver"]]
+    raw_count = len(fish)
+    capped_count = min(raw_count, max_per_event)
+
+    events.append({
+        "event_id": len(events) + 1,
+        "frame": frame_name,
+        "frame_index": i,
+        "fish_count_raw": raw_count,
+        "fish_count": capped_count,
+        "max_conf": max(d["confidence"] for d in fish) if fish else 0,
+        "detections": fish,
+    })
+
+    # Copy this frame to depth processing queue
+    src = frames_dir / frame_name
+    if src.exists():
+        shutil.copy2(src, depth_frames_dir / frame_name)
+
+# Write detection events
+with open(results_dir / "detection_events.json", "w") as f:
+    json.dump(events, f, indent=2)
+
+# Write deduplicated summary
+total_raw = sum(e["fish_count_raw"] for e in events)
+total_capped = sum(e["fish_count"] for e in events)
+with open(results_dir / "summary.csv", "w", newline="") as f:
+    writer = csv.DictWriter(f, fieldnames=[
+        "event_id", "frame", "fish_count", "fish_count_raw", "max_conf"])
+    writer.writeheader()
+    for e in events:
+        writer.writerow({
+            "event_id": e["event_id"],
+            "frame": e["frame"],
+            "fish_count": e["fish_count"],
+            "fish_count_raw": e["fish_count_raw"],
+            "max_conf": round(e["max_conf"], 4),
+        })
+
+n_total = len(frame_files)
+n_with_fish = sum(1 for jf in frame_files
+                  for _ in [json.load(open(jf))]
+                  if _["fish_count_filtered"] > 0)
+n_events = len(events)
+n_depth = len(list(depth_frames_dir.glob("*.png")))
+
+print(f"  Total frames:              {n_total}")
+print(f"  Frames with fish:          {n_with_fish}")
+print(f"  Unique detection events:   {n_events} (after {skip_window}-frame skip window)")
+print(f"  Fish count (raw):          {total_raw}")
+print(f"  Fish count (capped at {max_per_event}):  {total_capped}")
+print(f"  Frames queued for DA3:     {n_depth}")
+print(f"  Reduction ratio:           {n_total}→{n_depth} ({100*(1-n_depth/max(n_total,1)):.0f}% saved)")
+PYEOF
+
+echo ""
+
+# ─── STAGE 4: DA3 depth on selected frames only ────────────────────────
+DEPTH_FRAME_COUNT=$(ls $DEPTH_DIR/selected_frames/*.png 2>/dev/null | wc -l)
+
+if [ "$DEPTH_FRAME_COUNT" -gt 0 ]; then
+    echo "=== STAGE 4: DA3 Depth (${DEPTH_FRAME_COUNT} frames only) ==="
+    START=$(date +%s)
+
+    docker run --rm --runtime nvidia \
+      -v /jetson-ssd:/jetson-ssd \
+      da3-cuda-jetson \
+      images "$DEPTH_DIR/selected_frames" \
+      --model-dir depth-anything/DA3NESTED-GIANT-LARGE-1.1 \
+      --export-dir "$DEPTH_DIR/output" \
+      --export-format mini_npz \
+      --auto-cleanup
+
+    ELAPSED=$(($(date +%s) - START))
+    echo "  DA3 complete in ${ELAPSED}s"
+else
+    echo "=== STAGE 4: SKIPPED (no fish-bearing frames) ==="
+fi
+
+echo ""
+
+# ─── STAGE 5: Final report ──────────────────────────────────────────────
+echo "=== STAGE 5: Final Report ==="
+
+python3 << PYEOF
+import json, csv
+from pathlib import Path
+
+results_dir = Path("$RESULTS_DIR")
+events_file = results_dir / "detection_events.json"
+max_per_event = $MAX_PER_EVENT
+
+with open(events_file) as f:
+    events = json.load(f)
+
+total_raw = sum(e["fish_count_raw"] for e in events)
+total_capped = sum(e["fish_count"] for e in events)
+n_events = len(events)
+
+print("")
+print("  ┌─────────────────────────────────────────────────┐")
+print("  │  PIPELINE v2 RESULTS                            │")
+print("  ├─────────────────────────────────────────────────┤")
+print(f"  │  Detection events:         {n_events:<20}│")
+print(f"  │  Fish count (raw):         {total_raw:<20}│")
+print(f"  │  Fish count (capped):      {total_capped:<20}│")
+print(f"  │  Ecological cap:           {max_per_event} per event{'':<13}│")
+print(f"  │  Mean fish/event (capped): {total_capped/max(n_events,1):<20.1f}│")
+print("  └─────────────────────────────────────────────────┘")
+print("")
+print("  Compare with Benny's diver count using:")
+print("    python3 compare_to_official.py \\\\")
+print("      --ai $RESULTS_DIR/summary.csv \\\\")
+print("      --official <benny_csv>")
+print("")
+PYEOF
+
+echo "=== PIPELINE v2 COMPLETE ==="
+echo "Results: $RESULTS_DIR/"
+echo "  - detection_events.json  (full event data)"
+echo "  - summary.csv            (deduplicated counts)"
+echo "  - $DEPTH_DIR/output/     (3D depth for fish frames)"

--- a/edge/cfd/sidebyside2.py
+++ b/edge/cfd/sidebyside2.py
@@ -1,0 +1,81 @@
+import numpy as np
+import cv2, json, glob, os
+
+BASE       = "/jetson-ssd/compute/edge/depth-anything-v3-marine/ESPERANZA/T1_20m/V1/"
+FRAMES_DIR = BASE + "frames/"
+DEPTH_DIR  = BASE + "depth/"
+CFD_DIR    = BASE + "cfd/detections/"
+OUT_DIR    = BASE + "sidebyside2/"
+os.makedirs(OUT_DIR, exist_ok=True)
+FPB = 8
+
+def get_dvis(fn):
+    return os.path.join(DEPTH_DIR, f"batch_{fn//FPB:04d}", "depth_vis", f"{fn%FPB:04d}.jpg")
+
+def draw_boxes(img, dets):
+    for d in dets:
+        x1,y1,x2,y2 = [int(v) for v in d["bbox"]]
+        dv = d.get("likely_diver", False)
+        c = (0,100,255) if dv else (0,220,80)
+        cv2.rectangle(img,(x1,y1),(x2,y2),c,3)
+        cv2.putText(img,f"{'D' if dv else 'F'} {d['confidence']:.2f}",(x1+2,max(y1-6,18)),cv2.FONT_HERSHEY_SIMPLEX,0.55,c,2,cv2.LINE_AA)
+    return img
+
+def banner(img, text):
+    h,w = img.shape[:2]
+    ov = img.copy(); cv2.rectangle(ov,(0,0),(w,52),(0,0,0),-1); cv2.addWeighted(ov,0.6,img,0.4,0,img)
+    cv2.putText(img,text,(12,36),cv2.FONT_HERSHEY_SIMPLEX,0.8,(80,255,160),2,cv2.LINE_AA)
+    return img
+
+for fn in [121,119,120,117,118]:
+    stem = f"{fn:06d}"
+    fp = os.path.join(FRAMES_DIR, stem+".png")
+    jp = os.path.join(CFD_DIR, stem+".json")
+    dp = get_dvis(fn)
+    if not os.path.exists(fp) or not os.path.exists(jp): continue
+    with open(jp) as f: det = json.load(f)
+    fish_n = det.get("fish_count_filtered",0)
+    divers = det.get("diver_detections",0)
+    img = cv2.imread(fp); h,w = img.shape[:2]
+    img = banner(draw_boxes(img, det.get("detections",[])), f"CFD | {stem} | {fish_n} fish | {divers} diver flags")
+    dvis = cv2.resize(cv2.imread(dp),(w,h)) if os.path.exists(dp) else np.zeros((h,w,3),dtype=np.uint8)
+    dvis = banner(dvis.copy(), f"DA3 Depth | {stem} | red=close blue=far")
+    print(f"  Frame {fn}: img={img.shape} dvis={dvis.shape} dvis_exists={os.path.exists(dp)}")
+    div = np.full((h,8,3),30,dtype=np.uint8)
+    combined = cv2.resize(np.hstack([img,div,dvis]),(3840,int(h*3840/(w*2+8))),interpolation=cv2.INTER_LANCZOS4)
+    cv2.imwrite(os.path.join(OUT_DIR,f"{fn:06d}_sidebyside.jpg"),combined,[cv2.IMWRITE_JPEG_QUALITY,97])
+    print(f"  Saved {fn:06d}_sidebyside.jpg")
+
+print("Building filmstrip...")
+all_j = sorted(glob.glob(os.path.join(CFD_DIR,"*.json")))
+spaced = [int(os.path.splitext(os.path.basename(all_j[i]))[0]) for i in np.linspace(0,len(all_j)-1,5,dtype=int)]
+all_strip = sorted(set(spaced+[119,120,121]))[:8]
+print(f"Filmstrip frames: {all_strip}")
+SW,SH = 640,360
+panels = []
+for fn in all_strip:
+    stem=f"{fn:06d}"; jp=os.path.join(CFD_DIR,stem+".json"); fp=os.path.join(FRAMES_DIR,stem+".png"); dp=get_dvis(fn)
+    fish_n=0; dets=[]
+    if os.path.exists(jp):
+        with open(jp) as f: d=json.load(f)
+        fish_n=d.get("fish_count_filtered",0); dets=d.get("detections",[])
+    top=cv2.resize(draw_boxes(cv2.imread(fp),dets),(SW,SH),interpolation=cv2.INTER_LANCZOS4) if os.path.exists(fp) else np.zeros((SH,SW,3),dtype=np.uint8)
+    bot=cv2.resize(cv2.imread(dp),(SW,SH),interpolation=cv2.INTER_LANCZOS4) if os.path.exists(dp) else np.full((SH,SW,3),25,dtype=np.uint8)
+    hot = fn in [119,120,121]
+    if hot:
+        cv2.rectangle(top,(0,0),(SW-1,SH-1),(0,180,255),3)
+        cv2.rectangle(bot,(0,0),(SW-1,SH-1),(0,180,255),3)
+    lb=np.full((40,SW,3),15,dtype=np.uint8)
+    tag="* " if hot else ""
+    cv2.putText(lb,f"{tag}{stem} | {fish_n} fish",(6,28),cv2.FONT_HERSHEY_SIMPLEX,0.6,(0,200,255) if hot else (80,255,160),1,cv2.LINE_AA)
+    panels.append(np.vstack([top,np.full((5,SW,3),40,dtype=np.uint8),bot,lb]))
+
+gap=np.full((panels[0].shape[0],8,3),25,dtype=np.uint8)
+strip=panels[0]
+for p in panels[1:]: strip=np.hstack([strip,gap,p])
+hdr=np.full((70,strip.shape[1],3),15,dtype=np.uint8)
+cv2.putText(hdr,"ESPERANZA T1 | CFD (top) + DA3 depth (bottom) | * = hotspot",(16,48),cv2.FONT_HERSHEY_SIMPLEX,0.85,(80,255,160),2,cv2.LINE_AA)
+filmstrip=np.vstack([hdr,strip])
+cv2.imwrite(os.path.join(OUT_DIR,"filmstrip_sidebyside.jpg"),filmstrip,[cv2.IMWRITE_JPEG_QUALITY,97])
+print("Filmstrip saved.")
+print("Files:",os.listdir(OUT_DIR))


### PR DESCRIPTION
## Summary
- Adds `edge/cfd/` with the complete GPU-accelerated marine fish detection pipeline
- Dockerfile rebuilt on `dustynv/l4t-pytorch:r36.2.0` — fixes CUDA driver mismatch (113ms/frame vs 12s on CPU)
- Pipeline v2: extract → CFD → deduplicate → DA3 depth → report
- Calibrated against Benny's diver survey: 23 AI events vs 17 diver encounters (+35%)
- Includes comparison tool with plain-English output for non-technical reviewers

## What this replaces
The `edge/cfd/` directory previously existed only as untracked files on the Jetson. This commit brings them under version control with the latest GPU-fixed, v2 pipeline code.

## Test plan
- [x] Pipeline v2 ran end-to-end on ESPERANZA T1 20m V1 video (101 frames, 50 min total)
- [x] CFD GPU inference confirmed at 113ms/frame steady-state
- [x] Comparison against ground truth: 23 events vs 17 encounters
- [x] Dockerfile builds successfully on Jetson AGX Orin (L4T r35.2.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)